### PR TITLE
added sort and toggle alphabetical and reverse alphabetical order

### DIFF
--- a/src/components/IndividualPreserves.jsx
+++ b/src/components/IndividualPreserves.jsx
@@ -1,32 +1,30 @@
 
-function IndividualPreserves({preserve}){
+function IndividualPreserves({ preserve }) {
 
-return (
-
-
+  return (
 
 
-<div style={{ fontFamily: "Arial", backgroundColor:"rgba(255, 255, 255, 0)" }} className="card">
+
+
+    <div style={{ fontFamily: "Arial", backgroundColor: "rgba(255, 255, 255, 0)" }} className="card">
       <img src={preserve.image} className="card__image" alt="" />
       <div className="card__overlay">
         <div className="card__header">
           <svg className="card__arc" xmlns="http://www.w3.org/2000/svg"><path /></svg>
           <img className="card__thumb" src={preserve.image} alt="" />
           <div className="card__header-text">
-          
+
             <h3 className="card__title">{preserve.name}</h3>
-            {/* <span style={{ fontFamily: "Arial" }} className="card__status">{parseDATE(person.date)}</span> */}
           </div>
         </div>
-        <div style={{ fontFamily: "Arial" }}>{preserve.lat}</div>
-        <div style={{ fontFamily: "Arial" }}>{preserve.lng}</div>
+        <div style={{ fontFamily: "Arial", fontSize: "12px" }}><strong>Best Time</strong> {preserve.besttime}</div>
+        <div style={{ fontFamily: "Arial", fontSize: "12px" }}><strong>Best Locale</strong> {preserve.bestlocale[0]}</div>
+        <br></br>
 
-        {/* <p style={{ fontFamily: "Arial", fontSize: "10px" }} className="card__description">{person.description}</p> */}
-        {/* <Link style={{ fontSize: "15px" }} to={`/index/${id}`}>View Page</Link> */}
       </div>
     </div>
   );
-  
+
 
 
 

--- a/src/components/SearchPreserves.jsx
+++ b/src/components/SearchPreserves.jsx
@@ -1,110 +1,141 @@
 import IndividualPreserves from "./IndividualPreserves";
 import { useState, useEffect } from "react";
 
-function SearchPreserves({preserveMarkers, setPreserveMarkers}){
+function SearchPreserves({ preserveMarkers, setPreserveMarkers }) {
 
 
-    const darkSkyPreserves = [
-        { name: "Jasper National Park", lat: 52.8735, lng: -118.0814, image: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Athabasca_Glacier_on_the_Columbia_Icefield.jpg/800px-Athabasca_Glacier_on_the_Columbia_Icefield.jpg" },
-        { name: "Aoraki Mackenzie Intl Dark Sky Reserve", lat: -43.7340, lng: 170.0966, image: "https://darksky.org/app/uploads/2015/01/Crux_and_Church_aoraki.jpg" },
-        { name: "Brecon Beacons National Park", lat: 51.9479, lng: -3.3875, image: "https://upload.wikimedia.org/wikipedia/commons/3/3a/Brecon_beacons_arp.jpg" },
-        { name: "Natural Bridges National Monument", lat: 37.6096, lng: -110.0122, image: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a2/Night_sky_at_Owachomo_Bridge.jpg/800px-Night_sky_at_Owachomo_Bridge.jpg" },
-        { name: "Mont-Mégantic Dark Sky Reserve", lat: 45.4237, lng: -71.0916, image: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2Fd9%2Fb3%2F32%2Fd9b332e27decb669f0aa2124b6ca4e60.jpg&f=1&nofb=1&ipt=d2f78eba24a3c6915fe041ffcfad3668bd64a176eceb35e50b924e0cbb79f9f8&ipo=images" },
-        { name: "Exmoor National Park", lat: 51.1304, lng: -3.5542, image: "https://www.tripsavvy.com/thmb/E7XIbEApKiR0i6Y492UIRuXNLAQ=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/GettyImages-126384073-072da1fe62a0486fa853f6c4b9b7571a.jpg" },
-        { name: "NamibRand Nature Reserve", lat: -25.0393, lng: 15.0956, image: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fpanorama.solutions%2Fsites%2Fdefault%2Ffiles%2Fstyles%2Fx-large%2Fpublic%2Foryx%2520on%2520dune%25201.jpg%3Fitok%3DwtbYo-wM&f=1&nofb=1&ipt=0600bc2b363943f10550032b1a5f720073f555205334d16c51e8095d4d492f9c&ipo=images" },
-        { name: "Big Bend National Park", lat: 29.2497, lng: -103.2500, image: "https://www.nps.gov/common/uploads/grid_builder/bibe/crop16_9/D2B28621-0C4B-2389-52529785F84AB51F.jpg?width=640&quality=90&mode=crop" },
-        { name: "Grand Canyon-Parashant National Monument", lat: 36.9147, lng: -113.0289, image: "https://www.nps.gov/common/uploads/grid_builder/para/crop16_9/2969EAD9-1DD8-B71B-0B60C260DC394CF8.JPG?width=1300&quality=90&mode=crop" },
-        { name: "Cherry Springs State Park", lat: 41.6501, lng: -77.8165, image: "https://upload.wikimedia.org/wikipedia/commons/e/e4/CSSP_Sagittarius_Combine1C.jpg" },
-      ];
-      
-    // console.log(data)
-      const [query, setQuery] = useState("");
-      // const [queryUser, setQueryUser] = useState("");
-      // const [queryDescription, setQueryDescription] = useState("");
-    
-      const handleQueryChange = (event) => {
-        setQuery(event.target.value);
-      };
-      
-      // const handleQueryChangeUser = (event) => {
-      //   setQueryUser(event.target.value);
-      // };
-      
-      // const handleQueryChangeDescription = (event) => {
-      //   setQueryDescription(event.target.value);
-      // };
-      const filteredPreserves = darkSkyPreserves.filter((preserve) => {
-        return preserve.name.toLowerCase().includes(query.toLowerCase());
-      });
-    
-      // const filteredusers = data.filter((person) => {
-      //   return person.username.toLowerCase().includes(queryUser.toLowerCase());
-      // });
-    
-      // const filteredDescription = data.filter((person) => {
-      //   return person.description.toLowerCase().includes(queryDescription.toLowerCase());
-      // });
-    
-    // FOR LOCCATION NICKNAME
-      useEffect(() => {
-        const markerArray = filteredPreserves.map((preserve) => ({
-          lat: preserve.lat,
-          lng: preserve.lng,
-        }));
-    
-        setPreserveMarkers(markerArray); // Update mapMarkers based on filtered data
-      }, [query]); // Update markers when the query changes
-    
-      // // FOR USERS
-      // useEffect(() => {
-      //   const markerArray = filteredusers.map((person) => ({
-      //     lat: person.latitude,
-      //     lng: person.longitude,
-      //   }));
-    
-      //   setMapMarkers(markerArray); // Update mapMarkers based on filtered data
-      // }, [queryUser]); // Update markers when the query changes
-    
-      // useEffect(() => {
-      //   const markerArray = filteredDescription.map((person) => ({
-      //     lat: person.latitude,
-      //     lng: person.longitude,
-      //   }));
-    
-      //   setMapMarkers(markerArray); // Update mapMarkers based on filtered data
-      // }, [queryDescription]); // Update markers when the query changes
-    
-      return (
-        <div>
-          {/* <div>
-            <img onClick={planetsvis} style={{width:"100px"}} src={solarsystem}></img>
-            <strong>Search for a Location</strong>
-          </div> */}
-          {/* <div></div>
-                  <strong>Search for a Location</strong>
-    <div></div> */}
-    
-    
-    {/* <button onClick={locationNickanme7}>Location Nickname</button>   <button onClick={userNAME7}>Username</button> <button onClick={description7}>Description</button> */}
-    <input type="text" placeholder="Search for a Dark Sky Preserve" value={query} onChange={handleQueryChange} /> 
-    
-          {/* {locationNickanme ?<input type="text" placeholder="Search for a Location" value={query} onChange={handleQueryChange} /> :null} */}
-          {/* {usrname777?<input type="text" placeholder="Search for a User" value={queryUser} onChange={handleQueryChangeUser} />:null} */}
-          {/* {description777?<input type="text" placeholder="Search for a Description" value={handleQueryChangeDescription} onChange={handleQueryChangeDescription} />: null} */}
-    
-    
-    
-          <ul className="ultraelem"> 
-            {filteredPreserves.map((preserve) => (
-              <li className="listelem" style={{display:"flex",flexWrap:"wrap"}} key={preserve.lat + preserve.lng}>
-                <IndividualPreserves  preserve={preserve} />
-              </li>
-            ))}
-          </ul>
-        </div>
-      );
+  const darkSkyPreserves = [
+    { name: "Jasper National Park", besttime: "Clear nights throughout the year, with aurora borealis sightings more frequent in winter", bestlocale: ["Medicine Lake: Located 25 km outside Jasper, it offers clear skies and stunning views of twinkling stars.", "Pyramid Lake & Island: Just outside Jasper, Pyramid Lake provides an ideal spot for stargazing.", "Lake Annette: A few kilometers from Jasper, this glistening lake with sandy shorelines is perfect for stargazing."], lat: 52.8735, lng: -118.0814, image: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Athabasca_Glacier_on_the_Columbia_Icefield.jpg/800px-Athabasca_Glacier_on_the_Columbia_Icefield.jpg" },
+    { name: "Aoraki Mackenzie Intl Dark Sky Reserve", besttime: "Any clear night, especially during spring and summer", bestlocale: ["ObservÉtoiles at Au Diable Vert: Located in the Eastern Townships, it offers pristine dark skies.", "Mont-Mégantic National Park: Stand atop Mont-Mégantic for breathtaking views of stars, including the Andromeda Galaxy."], lat: -43.7340, lng: 170.0966, image: "https://darksky.org/app/uploads/2015/01/Crux_and_Church_aoraki.jpg" },
+    { name: "Brecon Beacons National Park", besttime: "Year-round, with guided stargazing tours available", bestlocale: ["Sugar Loaf Mountain: Offers panoramic views of the night sky.", "ObservÉtoiles at Au Diable Vert: Located in the Sutton outdoor center."], lat: 51.9479, lng: -3.3875, image: "https://upload.wikimedia.org/wikipedia/commons/3/3a/Brecon_beacons_arp.jpg" },
+    { name: "Natural Bridges National Monument", besttime: "Any clear night; see up to 15,000 stars", bestlocale: ["Campground: Enjoy unbeatable night skies even during a full moon.", "ASTROLab: Explore multimedia presentations and guided telescope viewing."], lat: 37.6096, lng: -110.0122, image: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a2/Night_sky_at_Owachomo_Bridge.jpg/800px-Night_sky_at_Owachomo_Bridge.jpg" },
+    { name: "Mont-Mégantic Dark Sky Reserve", besttime: "Visit between April and October for stargazing. The ASTROLab at the base of the 3,615-foot mountain offers guided telescope viewing during French-language evening tours", bestlocale: ["Mont-Mégantic is in Québec, Canada. It’s part of the Eastern Townships and home to the Mont-Mégantic International Dark Sky Reserve."], lat: 45.4237, lng: -71.0916, image: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2Fd9%2Fb3%2F32%2Fd9b332e27decb669f0aa2124b6ca4e60.jpg&f=1&nofb=1&ipt=d2f78eba24a3c6915fe041ffcfad3668bd64a176eceb35e50b924e0cbb79f9f8&ipo=images" },
+    { name: "Exmoor National Park", besttime: "Clear nights away from light pollution", bestlocale: ["Dunkery Beacon: Highest point in Exmoor, great for stargazing.", "Holdstone Hill: Offers dark skies and stunning celestial views."], lat: 51.1304, lng: -3.5542, image: "https://www.tripsavvy.com/thmb/E7XIbEApKiR0i6Y492UIRuXNLAQ=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/GettyImages-126384073-072da1fe62a0486fa853f6c4b9b7571a.jpg" },
+    { name: "NamibRand Nature Reserve", besttime: "Year-round, especially during the dry season", bestlocale: ["Desert Landscape: Vast, remote areas with minimal light pollution", "Sossusvlei Dunes: Unique stargazing experience in the desert."], lat: -25.0393, lng: 15.0956, image: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fpanorama.solutions%2Fsites%2Fdefault%2Ffiles%2Fstyles%2Fx-large%2Fpublic%2Foryx%2520on%2520dune%25201.jpg%3Fitok%3DwtbYo-wM&f=1&nofb=1&ipt=0600bc2b363943f10550032b1a5f720073f555205334d16c51e8095d4d492f9c&ipo=images" },
+    { name: "Big Bend National Park", besttime: "Any clear night in this designated Dark Sky Park", bestlocale: ["Chisos Basin: High elevation and clear skies for stargazing.", "Santa Elena Canyon: Stunning views of stars over the Rio Grande."], lat: 29.2497, lng: -103.2500, image: "https://www.nps.gov/common/uploads/grid_builder/bibe/crop16_9/D2B28621-0C4B-2389-52529785F84AB51F.jpg?width=640&quality=90&mode=crop" },
+    { name: "Grand Canyon-Parashant National Monument", besttime: "Clear nights away from city lights", bestlocale: ["Mount Logan: High elevation with minimal light pollution.", "Toroweap Overlook: Offers breathtaking views of the night sky."], lat: 36.9147, lng: -113.0289, image: "https://www.nps.gov/common/uploads/grid_builder/para/crop16_9/2969EAD9-1DD8-B71B-0B60C260DC394CF8.JPG?width=1300&quality=90&mode=crop" },
+    { name: "Cherry Springs State Park", besttime: "Visit during warm summer months (June to August) to avoid crowds. New moon nights are ideal for stargazing. The park is known for its exceptionally dark skies, making it one of the best places for stargazing on the East Coast", bestlocale: ["Located in Potter County, Pennsylvania, USA."], lat: 41.6501, lng: -77.8165, image: "https://upload.wikimedia.org/wikipedia/commons/e/e4/CSSP_Sagittarius_Combine1C.jpg" },
+  ];
+
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState("name");
+  const [toggle, setToggle] = useState(false);
+
+  console.log(sortKey)
+  const handleSortKeyChange = (e) => {
+    setSortKey(e.target.value);
+  };
+
+  const handleQueryChange = (event) => {
+    setQuery(event.target.value);
+  };
+
+  const filteredPreserves = darkSkyPreserves.filter((preserve) => {
+    if (sortKey === "bestlocale") {
+      return (preserve[sortKey][0]).includes(query.toLowerCase());
+
     }
-    
+    else {
+      return (preserve[sortKey]).includes(query.toLowerCase());
+    }
+  });
+
+
+  // FOR LOCCATION NICKNAME
+  useEffect(() => {
+    const markerArray = filteredPreserves.map((preserve) => ({
+      lat: preserve.lat,
+      lng: preserve.lng,
+    }));
+
+    setPreserveMarkers(markerArray); // Update mapMarkers based on filtered data
+  }, [query]); // Update markers when the query changes
+
+
+  filteredPreserves.sort((a, b) => {
+    if (toggle) {
+      if (sortKey === "bestlocale") {
+
+        if (a[sortKey][0] < b[sortKey][0]) {
+          return -1
+        }
+        else if (a[sortKey][0] > b[sortKey][0]) {
+          return 1
+        }
+        else return 0
+      }
+      else {
+        if (a[sortKey] < b[sortKey]) {
+          return -1
+        }
+        else if (a[sortKey] > b[sortKey]) {
+          return 1
+        }
+        else return 0
+      }
+
+    }
+    // if Toggle is False
+    else {
+
+      if (sortKey === "bestlocale") {
+
+        if (a[sortKey][0] < b[sortKey][0]) {
+          return 1
+        }
+        else if (a[sortKey][0] > b[sortKey][0]) {
+          return -1
+        }
+        else return 0
+      }
+      else {
+        if (a[sortKey] < b[sortKey]) {
+          return 1
+        }
+        else if (a[sortKey] > b[sortKey]) {
+          return -1
+        }
+        else return 0
+      }
+
+
+    }
+
+  }
+
+
+  )
+  console.log(filteredPreserves)
+
+
+
+
+  function handleToggle() {
+    setToggle(!toggle)
+  }
+  return (
+    <div>
+
+
+      <input type="text" placeholder="Search for a Dark Sky Preserve" value={query} onChange={handleQueryChange} />
+      <select style={{ textAlign: "center", width: "150px", backgroundColor: "#d8d8d8", borderRadius: "10px" }} value={sortKey} onChange={handleSortKeyChange}>
+        <option value="name">name</option>
+        <option value="besttime">best time</option>
+        <option value="bestlocale">best location</option>
+      </select>
+      {toggle ? <button onClick={handleToggle}>Normal Alphabetical</button> : <button onClick={handleToggle}>Reverse Alphabetical</button>}
+
+      <ul className="ultraelem">
+        {filteredPreserves.map((preserve) => (
+          <li className="listelem" style={{ display: "flex", flexWrap: "wrap" }} key={preserve.lat + preserve.lng}>
+            <IndividualPreserves preserve={preserve} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 
 
 


### PR DESCRIPTION
Added sort on the filter and a toggle button to toggle alphabetical or reverse alphabetical order for dark preserves components.

The components involved include the Index and show page for dark sky preserves.

three options were added to sort, which are name, location, and best time to view.



