### PR TITLE
css on preserve button alphabeticl sort

### DIFF
--- a/src/components/IndexPage/SearchPreserves.jsx
+++ b/src/components/IndexPage/SearchPreserves.jsx
@@ -121,7 +121,7 @@ function SearchPreserves({ preserveMarkers, setPreserveMarkers }) {
         <option value="bestlocale">best location</option>
       </select>
       <br></br>
-      {toggle ? <button className="preserveButton" onClick={handleToggle}>Normal Alphabetical</button> : <button onClick={handleToggle}>Reverse Alphabetical</button>}
+      {toggle ? <button className="preserveButton" onClick={handleToggle}>Normal Alphabetical</button> : <button className="preserveButton" onClick={handleToggle}>Reverse Alphabetical</button>}
 </div>
       <ul className="ultraelem">
         {filteredPreserves.map((preserve) => (


### PR DESCRIPTION
One CSS button was not styled because it was missing a className in the ternary operator. 

I added the className to it.

Now both buttons in the ternary are styled.