### PR TITLE
dream index page title change

### DIFF
--- a/src/dreams/DreamIndex.jsx
+++ b/src/dreams/DreamIndex.jsx
@@ -58,7 +58,7 @@ const DreamIndex = () => {
 
   return (
     <div style={styles.container(theme)}>
-      <h1 style={styles.title(theme)}>Dream Journal</h1>
+      <h1 style={styles.title(theme)}>Public Dream Log</h1>
 
       <div style={styles.filters}>
         <input


### PR DESCRIPTION
Changed title to avoid confusion, making it clear all dreams are public to logged in users.